### PR TITLE
STRUMPACK+ButterflyPACK example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,11 @@ set(SUPERLUDIST_DIR
     "${SUPERLUDIST_DIR}"
     CACHE PATH "Path to SuperLU_DIST installation directory")
 
+option(ENABLE_STRUMPACK "Enable STRUMPACK" ON)
+set(STRUMPACK_DIR
+    "${STRUMPACK_DIR}"
+    CACHE PATH "Path to STRUMPACK installation directory")
+
 option(ENABLE_TRILINOS "Enable TRILINOS" ON)
 set(TRILINOS_DIR
     "${Trilinos_DIR}"
@@ -98,6 +103,11 @@ if(ENABLE_SUPERLU)
   find_package(SUPERLUDIST REQUIRED)
 endif()
 
+# check for STRUMPACK
+if(ENABLE_STRUMPACK)
+  find_package(STRUMPACK REQUIRED)
+endif()
+
 # check for math
 find_library(MATH_LIBRARY NAMES m)
 
@@ -122,4 +132,7 @@ if(ENABLE_SUNDIALS)
 endif()
 if(ENABLE_TRILINOS)
   add_subdirectory(trilinos)
+endif()
+if(ENABLE_STRUMPACK)
+  add_subdirectory(strumpack)
 endif()

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ in the README.md files in the library subfolders.  For more information on the x
 |  sundials/ark_brusselator1D_FEM_sludist.cpp| SUNDIALS+SuperLU_Dist       | Chemical kinetics brusselator problem             |
 |  sundials/cv_petsc_ex7.c                   | SUNDIALS+PETSc              | 2D nonlinear PDE solution                         |
 |  trilinos/SimpleSolve_WithParameters.cpp   | Trilinos+SuperLU_Dist       | Small linear system direct solution               |
+|  strumpack/sparse.cpp                      | STRUMPACK+ButterflyPACK     | 3D Poisson problem with STRUMPACK preconditioner  |
 
 These examples are currently in the repo but will not be enabled in the xsdk-examples spack package until we release a new version of the xSDK.
 They can still be built using CMake directly.

--- a/strumpack/CMakeLists.txt
+++ b/strumpack/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.17)
+project(
+  strumpack-butterflypack
+  DESCRIPTION "STRUMPACK + ButterflyPACK Example"
+  LANGUAGES CXX)
+
+# set(CMAKE_CXX_COMPILER ${MPI_CXX_COMPILER})
+
+add_executable(sparse sparse.cpp)
+
+target_link_libraries(sparse PRIVATE STRUMPACK::strumpack)
+if(MATH_LIBRARY)
+  target_link_libraries(sparse PRIVATE ${MATH_LIBRARY})
+endif()
+
+install(TARGETS sparse RUNTIME DESTINATION bin)

--- a/strumpack/README.md
+++ b/strumpack/README.md
@@ -74,6 +74,9 @@ tuned using `--blr_rel_tol 1e-6` or `--hodlr_rel_tol 1e-6`
 
 To see the full list of command-line options, run: `./sparse --help`
 
+For more information on how to tune the preconditioners, see
+[here](https://portal.nersc.gov/project/sparse/strumpack/master/prec.html).
+
 ## License
 STRUMPACK -- STRUctured Matrix PACKage, Copyright (c) 2014-2022, The
 Regents of the University of California, through Lawrence Berkeley

--- a/strumpack/README.md
+++ b/strumpack/README.md
@@ -45,7 +45,7 @@ respectively. Without compression, the solver behaves as a sparse
 direct method. The sparse direct solver still uses iterative
 refinement, but typically only needs a single iteration.  When
 compression is enabled, the LU factorization is only approximate, and
-the solver is used as a preconditioner fot GMRES (or BiCGStab).
+the solver is used as a preconditioner for GMRES (or BiCGStab).
 
 
 ### Usage
@@ -55,7 +55,7 @@ the solver is used as a preconditioner fot GMRES (or BiCGStab).
  - This run solves a system corresponding to a discretization
     of the Laplace equation -Delta u = f with zero boundary
     conditions on a 100 x 100 x 100 grid, using STRUMPACK's
-    distributed LU factorizatio, and with both HODBF compression
+    distributed LU factorization, and with both HODBF compression
     for the largest fronts (dense sub-blocks in the sparse factors).
  - The output of the example is various information regarding the
     solver and solver performance.

--- a/strumpack/README.md
+++ b/strumpack/README.md
@@ -1,0 +1,98 @@
+<!--
+STRUMPACK -- STRUctured Matrix PACKage, Copyright (c) 2014-2022, The
+Regents of the University of California, through Lawrence Berkeley
+National Laboratory (subject to receipt of any required approvals from
+the U.S. Dept. of Energy).  All rights reserved.
+
+If you have questions about your rights to use or distribute this
+software, please contact Berkeley Lab's Technology Transfer Department
+at TTD@lbl.gov.
+
+NOTICE. This software is owned by the U.S. Department of Energy. As
+such, the U.S. Government has been granted for itself and others
+acting on its behalf a paid-up, nonexclusive, irrevocable, worldwide
+license in the Software to reproduce, prepare derivative works, and
+perform publicly and display publicly.  Beginning five (5) years after
+the date permission to assert copyright is obtained from the
+U.S. Department of Energy, and subject to any subsequent five (5) year
+renewals, the U.S. Government is granted for itself and others acting
+on its behalf a paid-up, nonexclusive, irrevocable, worldwide license
+in the Software to reproduce, prepare derivative works, distribute
+copies to the public, perform publicly and display publicly, and to
+permit others to do so.
+-->
+# STRUMPACK examples
+
+Example codes demonstrating the use of [STRUMPACK](https://portal.nersc.gov/project/sparse/strumpack/) using other XSDK packages ([ButterflyPACK](https://github.com/liuyangzhuan/ButterflyPACK)).
+
+## STRUMPACK + ButterflyPACK
+
+The `sparse.cpp` example demonstrates STRUMPACK's algebraic sparse
+direct solver and preconditioners for solving the 3-D Laplacian
+problem with zero boundary conditions on an n x n x n grid.  The
+number of unknowns is N=n^3.  The standard 7-point stencil is used,
+and we solve for the interior nodes only.
+
+STRUMPACK implements multifrontal sparse LU factorization, with the
+option of compression of the larger frontal matrices. Compression
+algorithms include HODLR (Hierarchically Off-Diagonal Low Rank) and
+HODBF (Hierarchically Off-Diagonal Butterfly), BLR (Block Low Rank),
+HSS (Hierarchically Semi Separable), lossy or lossless.
+
+After factorization, linear system can be solved using forward and
+backward substitution with the lower and upper triangular factors
+respectively. Without compression, the solver behaves as a sparse
+direct method. The sparse direct solver still uses iterative
+refinement, but typically only needs a single iteration.  When
+compression is enabled, the LU factorization is only approximate, and
+the solver is used as a preconditioner fot GMRES (or BiCGStab).
+
+
+### Usage
+
+**Sample run**:   `OMP_NUM_THREADS=4 mpirun -np 4 ./sparse 100 --sp_compression hodlr --hodlr_butterfly_levels 10`
+
+ - This run solves a system corresponding to a discretization
+    of the Laplace equation -Delta u = f with zero boundary
+    conditions on a 100 x 100 x 100 grid, using STRUMPACK's
+    distributed LU factorizatio, and with both HODBF compression
+    for the largest fronts (dense sub-blocks in the sparse factors).
+ - The output of the example is various information regarding the
+    solver and solver performance.
+
+Options for the compression algorithm include `none` (direct solver),
+`blr`, `lossy`/`lossless` (needs the ZFP library), `hodlr` (needs
+ButterflyPACK), `blr_hodlr` (needs ButterflyPACK). `blr_hodlr`
+combines both BLR (on medium sized blocks) and HODLR (on the largest
+blocks).
+
+The thresholds for using the compression schemes can be set using
+`--sp_compression_min_sep_size 1000` or, for specific formats
+``--sp_blr_min_sep_size 1000``.  The compression tolerance can be
+tuned using `--blr_rel_tol 1e-6` or `--hodlr_rel_tol 1e-6`
+
+
+To see the full list of command-line options, run: `./sparse --help`
+
+## License
+STRUMPACK -- STRUctured Matrix PACKage, Copyright (c) 2014-2022, The
+Regents of the University of California, through Lawrence Berkeley
+National Laboratory (subject to receipt of any required approvals from
+the U.S. Dept. of Energy).  All rights reserved.
+
+If you have questions about your rights to use or distribute this
+software, please contact Berkeley Lab's Technology Transfer Department
+at TTD@lbl.gov.
+
+NOTICE. This software is owned by the U.S. Department of Energy. As
+such, the U.S. Government has been granted for itself and others
+acting on its behalf a paid-up, nonexclusive, irrevocable, worldwide
+license in the Software to reproduce, prepare derivative works, and
+perform publicly and display publicly.  Beginning five (5) years after
+the date permission to assert copyright is obtained from the
+U.S. Department of Energy, and subject to any subsequent five (5) year
+renewals, the U.S. Government is granted for itself and others acting
+on its behalf a paid-up, nonexclusive, irrevocable, worldwide license
+in the Software to reproduce, prepare derivative works, distribute
+copies to the public, perform publicly and display publicly, and to
+permit others to do so

--- a/strumpack/sparse.cpp
+++ b/strumpack/sparse.cpp
@@ -38,18 +38,12 @@ typedef int integer;
 using namespace strumpack;
 
 int main(int argc, char* argv[]) {
-  int thread_level;
-  //MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &thread_level);
+  int thread_level, myrank;
   MPI_Init_thread(&argc, &argv, MPI_THREAD_FUNNELED, &thread_level);
-  int myrank;
   MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
   if (thread_level != MPI_THREAD_FUNNELED && myrank == 0)
     std::cout << "MPI implementation does not support MPI_THREAD_FUNNELED"
               << std::endl;
-  // if (thread_level != MPI_THREAD_MULTIPLE && myrank == 0)
-  //   std::cout << "MPI implementation does not support MPI_THREAD_MULTIPLE,"
-  //     " which might be needed for pt-scotch!" << std::endl;
-
   {
     int n = 30, nrhs = 1;
     if (argc > 1) n = atoi(argv[1]); // get grid size
@@ -60,12 +54,28 @@ int main(int argc, char* argv[]) {
       std::cout << "solving 3D " << n << "^3 Poisson problem"
                 << " with " << nrhs << " right hand sides" << std::endl;
 
+    // Create the main solver object, using an MPI communicator.
     StrumpackSparseSolverMPIDist<scalar,integer> spss(MPI_COMM_WORLD);
+
+    // The matching phase finds a column permutation that maximizes
+    // the diagonal elements. Since the 3D Poisson problem is already
+    // diagonally dominant, we can disable this matching.
     spss.options().set_matching(MatchingJob::NONE);
+
+    // A fill reducing ordering ordering is a symmtric permutation of
+    // the matrix that minimizes the fill in the sparse triangular
+    // factors. Since the problem here is defined on a regular mesh,
+    // we can use a simple geometric nested dissection algorithm (see
+    // also below spss.reorder(n, n, n) where the mesh dimensions are
+    // specified). For general sparse matrices, use any other option,
+    // such as the default ReorderingStrategy::METIS, or the parallel
+    // ReorderingStrategy::PARMETIS (if STRUMPACK was configured with
+    // PARMETIS support).
     spss.options().set_reordering_method(ReorderingStrategy::GEOMETRIC);
     spss.options().set_from_command_line(argc, argv);
 
-    // TODO directly build the distributed sparse matrix
+    // construct a sparse matrix from a simple 7 point stencil, with
+    // zero boundary conditions
     CSRMatrix<scalar,integer> A;
     if (!myrank) {
       int n2 = n * n;
@@ -94,18 +104,42 @@ int main(int argc, char* argv[]) {
           }
       A.set_symm_sparse();
     }
+    // This scatters the sparse matrix A from the root over all the
+    // ranks, using a 1D block row distribution, see
+    // https://portal.nersc.gov/project/sparse/strumpack/master/sparse_example_usage.html#autotoc_md9
     CSRMatrixMPI<scalar,integer> Adist(&A, MPI_COMM_WORLD, true);
+    // delete sequential sparse matrix (on the root)
     A = CSRMatrix<scalar,integer>();
 
     auto n_local = Adist.local_rows();
     DenseMatrix<scalar> b(n_local, nrhs), x(n_local, nrhs),
       x_exact(n_local, nrhs);
+
+    // construct a random exact solution
     x_exact.random();
+
+    // compute a right hand-side corresponding to exact solution
+    // x_exact
     Adist.spmv(x_exact, b);
 
+
+    // One can also directly pass the CSR rowptr, colind, and value
+    //   arrays, see
+    //   https://portal.nersc.gov/project/sparse/strumpack/master/classstrumpack_1_1SparseSolver.html
     spss.set_matrix(Adist);
+
+    // For geometric nested dissection, the the mesh dimensions n x n
+    // x n (and separator width if not 1) need to be provided. For
+    // other fill-reducing orderings, such as the default
+    // ReorderingStrategy::GEOMETRIC, just call spss.reorder();
     spss.reorder(n, n, n);
+
+    // the actual numerical factorization phase. If reorder() was not
+    // already called, it will be called by factor internally.
     spss.factor();
+
+    // solve a linear system Ax=b for x. If factor was not already
+    // called, then it will be called by solve internally.
     spss.solve(b, x);
 
     auto scaled_res = Adist.max_scaled_residual(x, b);
@@ -118,7 +152,6 @@ int main(int argc, char* argv[]) {
                 << relerr << std::endl;
     }
   }
-  //TimerList::Finalize();
   scalapack::Cblacs_exit(1);
   MPI_Finalize();
   return 0;

--- a/strumpack/sparse.cpp
+++ b/strumpack/sparse.cpp
@@ -1,0 +1,125 @@
+/*
+ * STRUMPACK -- STRUctured Matrix PACKage, Copyright (c) 2014-2022,
+ * The Regents of the University of California, through Lawrence
+ * Berkeley National Laboratory (subject to receipt of any required
+ * approvals from the U.S. Dept. of Energy).  All rights reserved.
+ *
+ * If you have questions about your rights to use or distribute this
+ * software, please contact Berkeley Lab's Technology Transfer
+ * Department at TTD@lbl.gov.
+ *
+ * NOTICE. This software is owned by the U.S. Department of Energy. As
+ * such, the U.S. Government has been granted for itself and others
+ * acting on its behalf a paid-up, nonexclusive, irrevocable,
+ * worldwide license in the Software to reproduce, prepare derivative
+ * works, and perform publicly and display publicly.  Beginning five
+ * (5) years after the date permission to assert copyright is obtained
+ * from the U.S. Department of Energy, and subject to any subsequent
+ * five (5) year renewals, the U.S. Government is granted for itself
+ * and others acting on its behalf a paid-up, nonexclusive,
+ * irrevocable, worldwide license in the Software to reproduce,
+ * prepare derivative works, distribute copies to the public, perform
+ * publicly and display publicly, and to permit others to do so.
+ *
+ * Developers: Pieter Ghysels, and others.
+ *             (Lawrence Berkeley National Lab, Computational Research
+ *             Division).
+ *
+ */
+#include <iostream>
+#include "StrumpackSparseSolverMPIDist.hpp"
+#include "sparse/CSRMatrix.hpp"
+#include "misc/TaskTimer.hpp"
+
+typedef double scalar;
+// typedef int64_t integer;  // to use 64 bit integers
+typedef int integer;
+
+using namespace strumpack;
+
+int main(int argc, char* argv[]) {
+  int thread_level;
+  //MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &thread_level);
+  MPI_Init_thread(&argc, &argv, MPI_THREAD_FUNNELED, &thread_level);
+  int myrank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+  if (thread_level != MPI_THREAD_FUNNELED && myrank == 0)
+    std::cout << "MPI implementation does not support MPI_THREAD_FUNNELED"
+              << std::endl;
+  // if (thread_level != MPI_THREAD_MULTIPLE && myrank == 0)
+  //   std::cout << "MPI implementation does not support MPI_THREAD_MULTIPLE,"
+  //     " which might be needed for pt-scotch!" << std::endl;
+
+  {
+    int n = 30, nrhs = 1;
+    if (argc > 1) n = atoi(argv[1]); // get grid size
+    else std::cout << "# please provide grid size" << std::endl;
+    // get number of right-hand sides
+    if (argc > 2) nrhs = std::max(1, atoi(argv[2]));
+    if (!myrank)
+      std::cout << "solving 3D " << n << "^3 Poisson problem"
+                << " with " << nrhs << " right hand sides" << std::endl;
+
+    StrumpackSparseSolverMPIDist<scalar,integer> spss(MPI_COMM_WORLD);
+    spss.options().set_matching(MatchingJob::NONE);
+    spss.options().set_reordering_method(ReorderingStrategy::GEOMETRIC);
+    spss.options().set_from_command_line(argc, argv);
+
+    // TODO directly build the distributed sparse matrix
+    CSRMatrix<scalar,integer> A;
+    if (!myrank) {
+      int n2 = n * n;
+      int N = n * n2;
+      int nnz = 7 * N - 6 * n2;
+      A = CSRMatrix<scalar,integer>(N, nnz);
+      integer* col_ptr = A.ptr();
+      integer* row_ind = A.ind();
+      scalar* val = A.val();
+
+      nnz = 0;
+      col_ptr[0] = 0;
+      for (integer xdim=0; xdim<n; xdim++)
+        for (integer ydim=0; ydim<n; ydim++)
+          for (integer zdim=0; zdim<n; zdim++) {
+            integer ind = zdim+ydim*n+xdim*n2;
+            val[nnz] = 6.0;
+            row_ind[nnz++] = ind;
+            if (zdim > 0)  { val[nnz] = -1.0; row_ind[nnz++] = ind-1; } // left
+            if (zdim < n-1){ val[nnz] = -1.0; row_ind[nnz++] = ind+1; } // right
+            if (ydim > 0)  { val[nnz] = -1.0; row_ind[nnz++] = ind-n; } // front
+            if (ydim < n-1){ val[nnz] = -1.0; row_ind[nnz++] = ind+n; } // back
+            if (xdim > 0)  { val[nnz] = -1.0; row_ind[nnz++] = ind-n2; } // up
+            if (xdim < n-1){ val[nnz] = -1.0; row_ind[nnz++] = ind+n2; } // down
+            col_ptr[ind+1] = nnz;
+          }
+      A.set_symm_sparse();
+    }
+    CSRMatrixMPI<scalar,integer> Adist(&A, MPI_COMM_WORLD, true);
+    A = CSRMatrix<scalar,integer>();
+
+    auto n_local = Adist.local_rows();
+    DenseMatrix<scalar> b(n_local, nrhs), x(n_local, nrhs),
+      x_exact(n_local, nrhs);
+    x_exact.random();
+    Adist.spmv(x_exact, b);
+
+    spss.set_matrix(Adist);
+    spss.reorder(n, n, n);
+    spss.factor();
+    spss.solve(b, x);
+
+    auto scaled_res = Adist.max_scaled_residual(x, b);
+    x.scaled_add(-1., x_exact);
+    auto relerr = x.normF() / x_exact.normF();
+    if (!myrank) {
+      std::cout << "# COMPONENTWISE SCALED RESIDUAL = "
+                << scaled_res << std::endl;
+      std::cout << "# relative error = ||x-x_exact||_F/||x_exact||_F = "
+                << relerr << std::endl;
+    }
+  }
+  //TimerList::Finalize();
+  scalapack::Cblacs_exit(1);
+  MPI_Finalize();
+  return 0;
+}


### PR DESCRIPTION
Add STRUMPACK (sparse) example, using ButterflyPACK.
I might also add a dense example.

For me this works using (just set the `STRUMPACK_DIR`):
```
export STRUMPACK_DIR=...
rm -rf build
mkdir build
cd build
cmake ../ \
      -DCMAKE_BUILD_TYPE=Debug \
      -DENABLE_STRUMPACK=ON \
      -DENABLE_HYPRE=OFF \
      -DENABLE_MFEM=OFF \
      -DENABLE_PETSC=OFF \
      -DENABLE_TRILINOS=OFF \
      -DENABLE_SUNDIALS=OFF \
      -DENABLE_SUPERLU=OFF
make
cd strumpack
export OMP_NUM_THREADS=4
# simple sparse direct solve of 3D Poisson problem
./sparse
# using preconditioner with block low rank compression
./sparse 50 --sp_compression blr --sp_compression_min_sep_size 1000
# using preconditioner with ButterflyPACK Hierarchically Off-Diagonal Butterfly compression
mpirun -n 2 ./sparse 50 --sp_compression hodlr --hodlr_butterfly_levels 10 --sp_compression_min_sep_size 1000
```